### PR TITLE
Fix the plugin for Mahara 24.04

### DIFF
--- a/sdk/GuzzleHttp/functions_include.php
+++ b/sdk/GuzzleHttp/functions_include.php
@@ -1,6 +1,6 @@
 <?php
 
 // Don't redefine the functions if included multiple times.
-if (!function_exists('GuzzleHttp\uri_template')) {
+if (!function_exists('GuzzleHttp\describe_type')) {
     require __DIR__ . '/functions.php';
 }


### PR DESCRIPTION
This is to resolve #3 

The change is backward compatible as `GuzzleHttp\describe_type` is present in older Mahara and GuzzleHttp versions.